### PR TITLE
Feat: Add object copy

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,3 +11,18 @@ export const copyObj = (origin) => {
 
 	return res;
 };
+
+export const copyMap = (origin) => {
+	if (origin instanceof Map) {
+		const res = new Map();
+		for (let [key, value] of origin) {
+			if (typeof origin.get(key) === 'object') {
+				const objValue = copyObj(value);
+				res.set(key, objValue);
+			} else {
+				res.set(key, origin.get(key));
+			}
+		}
+		return res;
+	}
+};

--- a/src/index.js
+++ b/src/index.js
@@ -26,3 +26,18 @@ export const copyMap = (origin) => {
 		return res;
 	}
 };
+
+export const copySet = (origin) => {
+	if (origin instanceof Set) {
+		const res = new Set();
+		for (let [key, value] of origin.entries()) {
+			if (typeof value === 'object') {
+				const objValue = copyObj(value);
+				res.add(key, objValue);
+			} else {
+				res.add(key, value);
+			}
+		}
+		return res;
+	}
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 export const deepCopy = (obj) => {
-	if (typeof obj !== 'object') throw new Error('unsupported type');
+	if (!(obj instanceof Object) || obj instanceof Array)
+		throw new Error('unsupported type');
 
 	if (obj instanceof Map) {
 		return copyMap(obj);
@@ -25,31 +26,27 @@ export const copyObj = (origin) => {
 };
 
 export const copyMap = (origin) => {
-	if (origin instanceof Map) {
-		const res = new Map();
-		for (let [key, value] of origin) {
-			if (typeof value === 'object') {
-				const objValue = copyObj(value);
-				res.set(key, objValue);
-			} else {
-				res.set(key, value);
-			}
+	const res = new Map();
+	for (let [key, value] of origin) {
+		if (typeof value === 'object') {
+			const objValue = copyObj(value);
+			res.set(key, objValue);
+		} else {
+			res.set(key, value);
 		}
-		return res;
 	}
+	return res;
 };
 
 export const copySet = (origin) => {
-	if (origin instanceof Set) {
-		const res = new Set();
-		for (let [key, value] of origin.entries()) {
-			if (typeof value === 'object') {
-				const objValue = copyObj(value);
-				res.add(key, objValue);
-			} else {
-				res.add(key, value);
-			}
+	const res = new Set();
+	for (let [key, value] of origin.entries()) {
+		if (typeof value === 'object') {
+			const objValue = copyObj(value);
+			res.add(key, objValue);
+		} else {
+			res.add(key, value);
 		}
-		return res;
 	}
+	return res;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,13 @@
+export const copyObj = (origin) => {
+	let res = {};
+
+	for (let key in origin) {
+		if (typeof origin[key] === 'object') {
+			res[key] = copyObj(origin[key]);
+		} else {
+			res[key] = origin[key];
+		}
+	}
+
+	return res;
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,15 @@
+export const deepCopy = (obj) => {
+	if (typeof obj !== 'object') throw new Error('unsupported type');
+
+	if (obj instanceof Map) {
+		return copyMap(obj);
+	} else if (obj instanceof Set) {
+		return copySet(obj);
+	} else {
+		return copyObj(obj);
+	}
+};
+
 export const copyObj = (origin) => {
 	let res = {};
 
@@ -16,11 +28,11 @@ export const copyMap = (origin) => {
 	if (origin instanceof Map) {
 		const res = new Map();
 		for (let [key, value] of origin) {
-			if (typeof origin.get(key) === 'object') {
+			if (typeof value === 'object') {
 				const objValue = copyObj(value);
 				res.set(key, objValue);
 			} else {
-				res.set(key, origin.get(key));
+				res.set(key, value);
 			}
 		}
 		return res;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,19 +1,19 @@
-const { copyObj } = require('.');
+const { copyObj, copyMap } = require('.');
 
-describe('test copy obj', () => {
+describe('test copy object', () => {
 	const obj = {
 		a: 1,
 	};
 
-	test('copied obj has the same property key and value', () => {
+	test('copied object has the same property key and value', () => {
 		expect(copyObj(obj)).toEqual(obj);
 	});
 
-	test('copied obj has a different reference from obj', () => {
+	test('copied object has a different reference from obj', () => {
 		expect(copyObj(obj)).not.toBe(obj);
 	});
 
-	test('it calls function recursively if the value is an object', () => {
+	test('recursive calls if the value is an object', () => {
 		const obj = {
 			b: {
 				c: 2,
@@ -22,5 +22,25 @@ describe('test copy obj', () => {
 
 		expect(copyObj(obj)).toEqual(obj);
 		expect(copyObj(obj)).not.toBe(obj);
+	});
+});
+
+describe('test copy map object', () => {
+	const mapObj = new Map();
+	mapObj.set('a', 1);
+
+	test('copy primitive property in map object', () => {
+		expect(copyMap(mapObj)).not.toBe(mapObj);
+		expect(copyMap(mapObj)).toEqual(mapObj);
+	});
+
+	test('copy object in map object', () => {
+		var mapObj = new Map([
+			['A', { value: 'valueA' }],
+			['B', { value: 'valueB' }],
+			['C', { value: 'valueC' }],
+		]);
+		expect(copyMap(mapObj)).not.toBe(mapObj);
+		expect(copyMap(mapObj)).toEqual(mapObj);
 	});
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,4 +1,4 @@
-const { copyObj, copyMap } = require('.');
+const { copyObj, copyMap, copySet } = require('.');
 
 describe('test copy object', () => {
 	const obj = {
@@ -44,3 +44,23 @@ describe('test copy map object', () => {
 		expect(copyMap(mapObj)).toEqual(mapObj);
 	});
 });
+
+describe('test copy set object', () => {
+	const setObj = new Set();
+	setObj.add(1);
+	setObj.add(5);
+
+	test('copy primitive property in set object', () => {
+		expect(copySet(setObj)).not.toBe(setObj);
+		expect(copySet(setObj)).toEqual(setObj);
+	});
+
+	test('copy primitive property in set object', () => {
+		setObj.add({ a: 1, b: 2 });
+
+		expect(copySet(setObj)).not.toBe(setObj);
+		expect(copySet(setObj)).toEqual(setObj);
+	});
+});
+
+// TODO: test object value reference

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,4 +1,4 @@
-const { copyObj, copyMap, copySet } = require('.');
+const { copyObj, copyMap, copySet, deepCopy } = require('.');
 
 describe('test copy object', () => {
 	const obj = {
@@ -63,4 +63,30 @@ describe('test copy set object', () => {
 	});
 });
 
+describe('test deepCopy()', () => {
+	test('deep copy object depends on object type', () => {
+		const setObj = new Set();
+		setObj.add(1);
+		setObj.add(5);
+		setObj.add({ a: 1, b: 2 });
+
+		const mapObj = new Map([
+			['A', { value: 'valueA' }],
+			['B', { value: 'valueB' }],
+			['C', { value: 'valueC' }],
+			['D', 'valueD'],
+		]);
+
+		const obj = {
+			a: 1,
+			b: {
+				c: 2,
+			},
+		};
+
+		expect(deepCopy(setObj)).toEqual(setObj);
+		expect(deepCopy(mapObj)).toEqual(mapObj);
+		expect(deepCopy(obj)).toEqual(obj);
+	});
+});
 // TODO: test object value reference

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,19 +1,16 @@
 const { copyObj, copyMap, copySet, deepCopy } = require('.');
 
-describe('test copy object', () => {
-	const obj = {
-		a: 1,
-	};
+describe('test copying object', () => {
+	test('copy primitive value in object', () => {
+		const obj = {
+			a: 1,
+		};
 
-	test('copied object has the same property key and value', () => {
+		expect(copyObj(obj)).not.toBe(obj);
 		expect(copyObj(obj)).toEqual(obj);
 	});
 
-	test('copied object has a different reference from obj', () => {
-		expect(copyObj(obj)).not.toBe(obj);
-	});
-
-	test('recursive calls if the value is an object', () => {
+	test('copy object value in object', () => {
 		const obj = {
 			b: {
 				c: 2,
@@ -25,37 +22,38 @@ describe('test copy object', () => {
 	});
 });
 
-describe('test copy map object', () => {
-	const mapObj = new Map();
-	mapObj.set('a', 1);
+describe('test copying map object', () => {
+	test('copy primitive value in map object', () => {
+		const mapObj = new Map();
+		mapObj.set('a', 1);
 
-	test('copy primitive property in map object', () => {
 		expect(copyMap(mapObj)).not.toBe(mapObj);
 		expect(copyMap(mapObj)).toEqual(mapObj);
 	});
 
-	test('copy object in map object', () => {
+	test('copy object value in map object', () => {
 		var mapObj = new Map([
 			['A', { value: 'valueA' }],
 			['B', { value: 'valueB' }],
 			['C', { value: 'valueC' }],
 		]);
+
 		expect(copyMap(mapObj)).not.toBe(mapObj);
 		expect(copyMap(mapObj)).toEqual(mapObj);
 	});
 });
 
-describe('test copy set object', () => {
+describe('test copying set object', () => {
 	const setObj = new Set();
-	setObj.add(1);
-	setObj.add(5);
 
-	test('copy primitive property in set object', () => {
+	test('copy primitive value in set object', () => {
+		setObj.add(1);
+		setObj.add(5);
 		expect(copySet(setObj)).not.toBe(setObj);
 		expect(copySet(setObj)).toEqual(setObj);
 	});
 
-	test('copy primitive property in set object', () => {
+	test('copy object value in set object', () => {
 		setObj.add({ a: 1, b: 2 });
 
 		expect(copySet(setObj)).not.toBe(setObj);
@@ -64,7 +62,14 @@ describe('test copy set object', () => {
 });
 
 describe('test deepCopy()', () => {
-	test('deep copy object depends on object type', () => {
+	test('make a deep copy of an object depends on type', () => {
+		const obj = {
+			a: 1,
+			b: {
+				c: 2,
+			},
+		};
+
 		const setObj = new Set();
 		setObj.add(1);
 		setObj.add(5);
@@ -77,16 +82,17 @@ describe('test deepCopy()', () => {
 			['D', 'valueD'],
 		]);
 
-		const obj = {
-			a: 1,
-			b: {
-				c: 2,
-			},
-		};
-
+		expect(deepCopy(obj)).toEqual(obj);
 		expect(deepCopy(setObj)).toEqual(setObj);
 		expect(deepCopy(mapObj)).toEqual(mapObj);
-		expect(deepCopy(obj)).toEqual(obj);
+	});
+
+	test('throw an error if the parameter is primitive', () => {
+		expect(() => deepCopy(4)).toThrow('unsupported type');
+		expect(() => deepCopy('string')).toThrow('unsupported type');
+	});
+
+	test('throw an error if the parameter type is array', () => {
+		expect(() => deepCopy([1, 2, 3])).toThrow('unsupported type');
 	});
 });
-// TODO: test object value reference

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,0 +1,26 @@
+const { copyObj } = require('.');
+
+describe('test copy obj', () => {
+	const obj = {
+		a: 1,
+	};
+
+	test('copied obj has the same property key and value', () => {
+		expect(copyObj(obj)).toEqual(obj);
+	});
+
+	test('copied obj has a different reference from obj', () => {
+		expect(copyObj(obj)).not.toBe(obj);
+	});
+
+	test('it calls function recursively if the value is an object', () => {
+		const obj = {
+			b: {
+				c: 2,
+			},
+		};
+
+		expect(copyObj(obj)).toEqual(obj);
+		expect(copyObj(obj)).not.toBe(obj);
+	});
+});


### PR DESCRIPTION
### description

- 깊은 복사 재귀함수 구현: 객체, Set 객체, Map 객체에 대한 깊은 복사
- 테스트 코드 작성

### question
- 유사한 패턴을 묶어 공통로직으로 재사용하는 방법이 있을까요?
  - 각각의 타입에 따라 복사 로직을 따로 구현하고, 
  deepCopy() 함수에서 전달받은 인자의 타입에 따라 각 함수를 호출하도록 구현했습니다.  
  각각 순회하는 방식, 프로퍼티를 추가하는 방식이 달라 따로 구현을 했는데  더 효율적인 방법이 있을지 궁금합니다.
