### PR TITLE
Refactor deepCopy func

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,23 @@
+import { key, TYPE } from './utils/constants';
+
 export const deepCopy = (obj) => {
 	if (!(obj instanceof Object) || obj instanceof Array)
 		throw new Error('unsupported type');
 
-	if (obj instanceof Map) {
+	const objType = Object.prototype.toString.call(obj);
+	return copy[objType](obj);
+};
+
+export const copy = {
+	[key(TYPE.MAP)](obj) {
 		return copyMap(obj);
-	} else if (obj instanceof Set) {
+	},
+	[key(TYPE.SET)](obj) {
 		return copySet(obj);
-	} else {
+	},
+	[key(TYPE.OBJECT)](obj) {
 		return copyObj(obj);
-	}
+	},
 };
 
 export const copyObj = (origin) => {

--- a/src/index.js
+++ b/src/index.js
@@ -41,32 +41,36 @@ export const copyPrimitive = (value) => {
 
 export const copyArray = (array) => {
 	const res = [];
-	for (let key in array) {
-		res[key] = deepCopy(array[key]);
-	}
+	iterateObj2(array, (key, value) => (res[key] = value));
 	return res;
 };
 
 export const copyObj = (origin) => {
 	let res = {};
-	for (let key in origin) {
-		res[key] = deepCopy(origin[key]);
-	}
+	iterateObj2(origin, (key, value) => (res[key] = value));
 	return res;
 };
 
 export const copyMap = (origin) => {
 	const res = new Map();
-	for (let [key, value] of origin) {
-		res.set(key, deepCopy(value));
-	}
+	iterateObj(origin, (key, value) => res.set(key, value));
 	return res;
 };
 
 export const copySet = (origin) => {
 	const res = new Set();
-	for (let value of origin.values()) {
-		res.add(deepCopy(value));
-	}
+	iterateObj(origin.entries(), (value) => res.add(value));
 	return res;
+};
+
+const iterateObj = (obj, setValueFunc) => {
+	for (let [key, value] of obj) {
+		setValueFunc(key, deepCopy(value));
+	}
+};
+
+const iterateObj2 = (obj, setValueFunc) => {
+	for (let key in obj) {
+		setValueFunc(key, deepCopy(obj[key]));
+	}
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { key, TYPE } from './utils/constants';
+import { key, TYPE, ITERATE_TYPE } from './utils/constants';
 
 export const deepCopy = (obj) => {
 	let objType = '';
@@ -41,36 +41,37 @@ export const copyPrimitive = (value) => {
 
 export const copyArray = (array) => {
 	const res = [];
-	iterateObj2(array, (key, value) => (res[key] = value));
+	iterate[ITERATE_TYPE.FOR_IN](array, (key, value) => (res[key] = value));
 	return res;
 };
 
 export const copyObj = (origin) => {
 	let res = {};
-	iterateObj2(origin, (key, value) => (res[key] = value));
+	iterate[ITERATE_TYPE.FOR_IN](origin, (key, value) => (res[key] = value));
 	return res;
 };
 
 export const copyMap = (origin) => {
 	const res = new Map();
-	iterateObj(origin, (key, value) => res.set(key, value));
+	iterate[ITERATE_TYPE.FOR_OF](origin, (key, value) => res.set(key, value));
 	return res;
 };
 
 export const copySet = (origin) => {
 	const res = new Set();
-	iterateObj(origin.entries(), (value) => res.add(value));
+	iterate[ITERATE_TYPE.FOR_OF](origin.entries(), (value) => res.add(value));
 	return res;
 };
 
-const iterateObj = (obj, setValueFunc) => {
-	for (let [key, value] of obj) {
-		setValueFunc(key, deepCopy(value));
-	}
-};
-
-const iterateObj2 = (obj, setValueFunc) => {
-	for (let key in obj) {
-		setValueFunc(key, deepCopy(obj[key]));
-	}
+const iterate = {
+	[ITERATE_TYPE.FOR_IN](obj, setValueFunc) {
+		for (let key in obj) {
+			setValueFunc(key, deepCopy(obj[key]));
+		}
+	},
+	[ITERATE_TYPE.FOR_OF](obj, setValueFunc) {
+		for (let [key, value] of obj) {
+			setValueFunc(key, deepCopy(value));
+		}
+	},
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import { key, TYPE, ITERATE_TYPE } from './utils/constants';
+import { copy } from './utils/copyType';
+import { TYPE } from './utils/constants';
 
 export const deepCopy = (obj) => {
 	let objType = '';
@@ -8,70 +9,4 @@ export const deepCopy = (obj) => {
 		objType = TYPE.PRIMITIVE;
 	}
 	return copy[objType](obj);
-};
-
-export const copy = {
-	[key(TYPE.MAP)](obj) {
-		return copyMap(obj);
-	},
-	[key(TYPE.SET)](obj) {
-		return copySet(obj);
-	},
-	[key(TYPE.OBJECT)](obj) {
-		return copyObj(obj);
-	},
-	[key(TYPE.ARRAY)](arr) {
-		return copyArray(arr);
-	},
-	[key(TYPE.NULL)]() {
-		return null;
-	},
-	[key(TYPE.UNDEFINED)]() {
-		return undefined;
-	},
-	[TYPE.PRIMITIVE](obj) {
-		return copyPrimitive(obj);
-	},
-};
-
-export const copyPrimitive = (value) => {
-	const res = value;
-	return res;
-};
-
-export const copyArray = (array) => {
-	const res = [];
-	iterate[ITERATE_TYPE.FOR_IN](array, (key, value) => (res[key] = value));
-	return res;
-};
-
-export const copyObj = (origin) => {
-	let res = {};
-	iterate[ITERATE_TYPE.FOR_IN](origin, (key, value) => (res[key] = value));
-	return res;
-};
-
-export const copyMap = (origin) => {
-	const res = new Map();
-	iterate[ITERATE_TYPE.FOR_OF](origin, (key, value) => res.set(key, value));
-	return res;
-};
-
-export const copySet = (origin) => {
-	const res = new Set();
-	iterate[ITERATE_TYPE.FOR_OF](origin.entries(), (value) => res.add(value));
-	return res;
-};
-
-const iterate = {
-	[ITERATE_TYPE.FOR_IN](obj, setValueFunc) {
-		for (let key in obj) {
-			setValueFunc(key, deepCopy(obj[key]));
-		}
-	},
-	[ITERATE_TYPE.FOR_OF](obj, setValueFunc) {
-		for (let [key, value] of obj) {
-			setValueFunc(key, deepCopy(value));
-		}
-	},
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,12 @@
 import { key, TYPE } from './utils/constants';
 
 export const deepCopy = (obj) => {
-	if (!(obj instanceof Object) || obj instanceof Array)
-		throw new Error('unsupported type');
-
-	const objType = Object.prototype.toString.call(obj);
+	let objType = '';
+	if (typeof obj === 'object') {
+		objType = Object.prototype.toString.call(obj);
+	} else {
+		objType = TYPE.PRIMITIVE;
+	}
 	return copy[objType](obj);
 };
 
@@ -18,17 +20,21 @@ export const copy = {
 	[key(TYPE.OBJECT)](obj) {
 		return copyObj(obj);
 	},
+	[TYPE.PRIMITIVE](obj) {
+		return copyPrimitive(obj);
+	},
+};
+
+export const copyPrimitive = (value) => {
+	const res = value;
+	return res;
 };
 
 export const copyObj = (origin) => {
 	let res = {};
 
 	for (let key in origin) {
-		if (typeof origin[key] === 'object') {
-			res[key] = copyObj(origin[key]);
-		} else {
-			res[key] = origin[key];
-		}
+		res[key] = deepCopy(origin[key]);
 	}
 
 	return res;
@@ -36,26 +42,20 @@ export const copyObj = (origin) => {
 
 export const copyMap = (origin) => {
 	const res = new Map();
+
 	for (let [key, value] of origin) {
-		if (typeof value === 'object') {
-			const objValue = copyObj(value);
-			res.set(key, objValue);
-		} else {
-			res.set(key, value);
-		}
+		res.set(key, deepCopy(value));
 	}
+
 	return res;
 };
 
 export const copySet = (origin) => {
 	const res = new Set();
+
 	for (let [key, value] of origin.entries()) {
-		if (typeof value === 'object') {
-			const objValue = copyObj(value);
-			res.add(key, objValue);
-		} else {
-			res.add(key, value);
-		}
+		res.add(deepCopy(value));
 	}
+
 	return res;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,15 @@ export const copy = {
 	[key(TYPE.OBJECT)](obj) {
 		return copyObj(obj);
 	},
+	[key(TYPE.ARRAY)](arr) {
+		return copyArray(arr);
+	},
+	[key(TYPE.NULL)]() {
+		return null;
+	},
+	[key(TYPE.UNDEFINED)]() {
+		return undefined;
+	},
 	[TYPE.PRIMITIVE](obj) {
 		return copyPrimitive(obj);
 	},
@@ -30,32 +39,34 @@ export const copyPrimitive = (value) => {
 	return res;
 };
 
+export const copyArray = (array) => {
+	const res = [];
+	for (let key in array) {
+		res[key] = deepCopy(array[key]);
+	}
+	return res;
+};
+
 export const copyObj = (origin) => {
 	let res = {};
-
 	for (let key in origin) {
 		res[key] = deepCopy(origin[key]);
 	}
-
 	return res;
 };
 
 export const copyMap = (origin) => {
 	const res = new Map();
-
 	for (let [key, value] of origin) {
 		res.set(key, deepCopy(value));
 	}
-
 	return res;
 };
 
 export const copySet = (origin) => {
 	const res = new Set();
-
-	for (let [key, value] of origin.entries()) {
+	for (let value of origin.values()) {
 		res.add(deepCopy(value));
 	}
-
 	return res;
 };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,4 +1,5 @@
-const { copyObj, copyMap, copySet, deepCopy } = require('.');
+const { copyObj, copyMap, copySet, deepCopy, copy } = require('.');
+const { TYPE, key } = require('./utils/constants');
 
 describe('test copying object', () => {
 	test('copy primitive value in object', () => {
@@ -94,5 +95,35 @@ describe('test deepCopy()', () => {
 
 	test('throw an error if the parameter type is array', () => {
 		expect(() => deepCopy([1, 2, 3])).toThrow('unsupported type');
+	});
+});
+
+describe('test obj', () => {
+	const obj = {
+		A: 'valueA',
+	};
+
+	const mapObject = new Map([
+		['A', { value: 'valueA' }],
+		['B', { value: 'valueB' }],
+		['C', { value: 'valueC' }],
+		['D', 'valueD'],
+	]);
+
+	const setObj = new Set();
+	setObj.add(1);
+	setObj.add(5);
+	setObj.add({ a: 1, b: 2 });
+
+	test('get object property with Object.prototype', () => {
+		const typeOfMap = Object.prototype.toString.call(mapObject);
+		expect(typeOfMap).toBe(key(TYPE.MAP));
+		expect(copy[typeOfMap](mapObject)).toEqual(mapObject);
+
+		const typeOfObject = Object.prototype.toString.call(obj);
+		expect(typeOfObject).toBe(key(TYPE.OBJECT));
+		expect(copy[typeOfObject](obj)).toEqual(obj);
+
+		// TODO: add test case of other type
 	});
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -88,13 +88,9 @@ describe('test deepCopy()', () => {
 		expect(deepCopy(mapObj)).toEqual(mapObj);
 	});
 
-	test('throw an error if the parameter is primitive', () => {
-		expect(() => deepCopy(4)).toThrow('unsupported type');
-		expect(() => deepCopy('string')).toThrow('unsupported type');
-	});
-
-	test('throw an error if the parameter type is array', () => {
-		expect(() => deepCopy([1, 2, 3])).toThrow('unsupported type');
+	test('copy primitive type value', () => {
+		expect(deepCopy(4)).toBe(4);
+		expect(deepCopy('string')).toBe('string');
 	});
 });
 
@@ -125,5 +121,17 @@ describe('test obj', () => {
 		expect(copy[typeOfObject](obj)).toEqual(obj);
 
 		// TODO: add test case of other type
+	});
+
+	test('test recursive call deepCopy', () => {
+		const obj = {
+			a: 1,
+			b: {
+				c: 3,
+				d: 6,
+			},
+		};
+
+		expect(deepCopy(obj)).toEqual(obj);
 	});
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -149,6 +149,12 @@ describe('test obj', () => {
 		expect(deepCopy(arr)).toEqual(arr);
 		expect(deepCopy(arr)).not.toBe(arr);
 	});
+
+	test('test copying symbol', () => {
+		const symbol = Symbol('foo');
+		expect(deepCopy(symbol)).toEqual(symbol);
+		expect(deepCopy(symbol)).not.toBe(symbol);
+	});
 });
 
 describe('test except case', () => {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,5 +1,7 @@
-const { copyObj, copyMap, copySet, deepCopy, copy } = require('.');
-const { TYPE, key } = require('./utils/constants');
+const { deepCopy } = require('.');
+const func = require('./utils/copyFunctions');
+const { copy } = require('./utils/copyType');
+const { TYPE, wrapKey } = require('./utils/constants');
 
 describe('test copying object', () => {
 	test('copy primitive value in object', () => {
@@ -7,8 +9,8 @@ describe('test copying object', () => {
 			a: 1,
 		};
 
-		expect(copyObj(obj)).not.toBe(obj);
-		expect(copyObj(obj)).toEqual(obj);
+		expect(func.copyObj(obj)).not.toBe(obj);
+		expect(func.copyObj(obj)).toEqual(obj);
 	});
 
 	test('copy object value in object', () => {
@@ -18,8 +20,8 @@ describe('test copying object', () => {
 			},
 		};
 
-		expect(copyObj(obj)).toEqual(obj);
-		expect(copyObj(obj)).not.toBe(obj);
+		expect(func.copyObj(obj)).toEqual(obj);
+		expect(func.copyObj(obj)).not.toBe(obj);
 	});
 });
 
@@ -28,8 +30,8 @@ describe('test copying map object', () => {
 		const mapObj = new Map();
 		mapObj.set('a', 1);
 
-		expect(copyMap(mapObj)).not.toBe(mapObj);
-		expect(copyMap(mapObj)).toEqual(mapObj);
+		expect(func.copyMap(mapObj)).not.toBe(mapObj);
+		expect(func.copyMap(mapObj)).toEqual(mapObj);
 	});
 
 	test('copy object value in map object', () => {
@@ -39,8 +41,8 @@ describe('test copying map object', () => {
 			['C', { value: 'valueC' }],
 		]);
 
-		expect(copyMap(mapObj)).not.toBe(mapObj);
-		expect(copyMap(mapObj)).toEqual(mapObj);
+		expect(func.copyMap(mapObj)).not.toBe(mapObj);
+		expect(func.copyMap(mapObj)).toEqual(mapObj);
 	});
 
 	test('copy map object value in map object', () => {
@@ -61,15 +63,15 @@ describe('test copying set object', () => {
 	test('copy primitive value in set object', () => {
 		setObj.add(1);
 		setObj.add(5);
-		expect(copySet(setObj)).not.toBe(setObj);
-		expect(copySet(setObj)).toEqual(setObj);
+		expect(func.copySet(setObj)).not.toBe(setObj);
+		expect(func.copySet(setObj)).toEqual(setObj);
 	});
 
 	test('copy object value in set object', () => {
 		setObj.add({ a: 1, b: 2 });
 
-		expect(copySet(setObj)).not.toBe(setObj);
-		expect(copySet(setObj)).toEqual(setObj);
+		expect(func.copySet(setObj)).not.toBe(setObj);
+		expect(func.copySet(setObj)).toEqual(setObj);
 	});
 
 	test('copy set value in set object', () => {
@@ -132,11 +134,11 @@ describe('test obj', () => {
 
 	test('get object property with Object.prototype', () => {
 		const typeOfMap = Object.prototype.toString.call(mapObject);
-		expect(typeOfMap).toBe(key(TYPE.MAP));
+		expect(typeOfMap).toBe(wrapKey(TYPE.MAP));
 		expect(copy[typeOfMap](mapObject)).toEqual(mapObject);
 
 		const typeOfObject = Object.prototype.toString.call(obj);
-		expect(typeOfObject).toBe(key(TYPE.OBJECT));
+		expect(typeOfObject).toBe(wrapKey(TYPE.OBJECT));
 		expect(copy[typeOfObject](obj)).toEqual(obj);
 
 		// TODO: add test case of other type

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -42,6 +42,17 @@ describe('test copying map object', () => {
 		expect(copyMap(mapObj)).not.toBe(mapObj);
 		expect(copyMap(mapObj)).toEqual(mapObj);
 	});
+
+	test('copy map object value in map object', () => {
+		const map = new Map();
+		map.set('a', 1);
+		const map2 = new Map();
+		map2.set('b', 2);
+		map.set('c', map2);
+
+		expect(deepCopy(map)).toEqual(map);
+		expect(deepCopy(map)).not.toBe(map);
+	});
 });
 
 describe('test copying set object', () => {
@@ -59,6 +70,14 @@ describe('test copying set object', () => {
 
 		expect(copySet(setObj)).not.toBe(setObj);
 		expect(copySet(setObj)).toEqual(setObj);
+	});
+
+	test('copy set value in set object', () => {
+		const set2 = new Set();
+		set2.add(5);
+		setObj.add(set2);
+		expect(deepCopy(set2)).toEqual(set2);
+		expect(deepCopy(set2)).not.toBe(set2);
 	});
 });
 
@@ -123,15 +142,21 @@ describe('test obj', () => {
 		// TODO: add test case of other type
 	});
 
-	test('test recursive call deepCopy', () => {
-		const obj = {
-			a: 1,
-			b: {
-				c: 3,
-				d: 6,
-			},
-		};
+	test('test copying array', () => {
+		const arr = [1, 2, 3];
+		expect(deepCopy(arr)).toEqual(arr);
+		expect(deepCopy(arr)).not.toBe(arr);
+	});
+});
 
+describe('test except case', () => {
+	const obj = {
+		a: null,
+		b: undefined,
+	};
+
+	test('test null, undefined case', () => {
 		expect(deepCopy(obj)).toEqual(obj);
+		expect(deepCopy(obj)).not.toBe(obj);
 	});
 });

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -13,11 +13,6 @@ export const ITERATE_TYPE = {
 	FOR_OF: 'FOR_OF',
 };
 
-export const handleType = (obj) => {
-	const objType = Object.prototype.toString.call(obj);
-	return copy[objType](obj);
-};
-
-export const key = (type) => {
+export const wrapKey = (type) => {
 	return `[object ${type}]`;
 };

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -3,6 +3,7 @@ export const TYPE = {
 	SET: 'Set',
 	OBJECT: 'Object',
 	ARRAY: 'Array',
+	SYMBOL: 'Symbol',
 	PRIMITIVE: 'Primitive',
 	NULL: 'Null',
 	UNDEFINED: 'Undefined',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -3,6 +3,7 @@ export const TYPE = {
 	SET: 'Set',
 	OBJECT: 'Object',
 	ARRAY: 'Array',
+	PRIMITIVE: 'Primitive',
 };
 
 export const handleType = (obj) => {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -4,6 +4,8 @@ export const TYPE = {
 	OBJECT: 'Object',
 	ARRAY: 'Array',
 	PRIMITIVE: 'Primitive',
+	NULL: 'Null',
+	UNDEFINED: 'Undefined',
 };
 
 export const handleType = (obj) => {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,15 @@
+export const TYPE = {
+	MAP: 'Map',
+	SET: 'Set',
+	OBJECT: 'Object',
+	ARRAY: 'Array',
+};
+
+export const handleType = (obj) => {
+	const objType = Object.prototype.toString.call(obj);
+	return copy[objType](obj);
+};
+
+export const key = (type) => {
+	return `[object ${type}]`;
+};

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -8,6 +8,11 @@ export const TYPE = {
 	UNDEFINED: 'Undefined',
 };
 
+export const ITERATE_TYPE = {
+	FOR_IN: 'FOR_IN',
+	FOR_OF: 'FOR_OF',
+};
+
 export const handleType = (obj) => {
 	const objType = Object.prototype.toString.call(obj);
 	return copy[objType](obj);

--- a/src/utils/copyFunctions.js
+++ b/src/utils/copyFunctions.js
@@ -1,0 +1,31 @@
+import { recurse } from './recurse';
+import { ITERATE_TYPE } from './constants';
+
+export const copyPrimitive = (value) => {
+	const res = value;
+	return res;
+};
+
+export const copyArray = (array) => {
+	const res = [];
+	recurse[ITERATE_TYPE.FOR_IN](array, (key, value) => (res[key] = value));
+	return res;
+};
+
+export const copyObj = (origin) => {
+	let res = {};
+	recurse[ITERATE_TYPE.FOR_IN](origin, (key, value) => (res[key] = value));
+	return res;
+};
+
+export const copyMap = (origin) => {
+	const res = new Map();
+	recurse[ITERATE_TYPE.FOR_OF](origin, (key, value) => res.set(key, value));
+	return res;
+};
+
+export const copySet = (origin) => {
+	const res = new Set();
+	recurse[ITERATE_TYPE.FOR_OF](origin.entries(), (value) => res.add(value));
+	return res;
+};

--- a/src/utils/copyFunctions.js
+++ b/src/utils/copyFunctions.js
@@ -29,3 +29,10 @@ export const copySet = (origin) => {
 	recurse[ITERATE_TYPE.FOR_OF](origin.entries(), (value) => res.add(value));
 	return res;
 };
+
+export const copySymbol = (origin) => {
+	const res = new Symbol('res');
+	const key = Symbol.keyFor(origin);
+	res = Symbol.for(key);
+	return res;
+};

--- a/src/utils/copyType.js
+++ b/src/utils/copyType.js
@@ -1,0 +1,26 @@
+import * as func from './copyFunctions';
+import { wrapKey, TYPE } from './constants';
+
+export const copy = {
+	[wrapKey(TYPE.MAP)](obj) {
+		return func.copyMap(obj);
+	},
+	[wrapKey(TYPE.SET)](obj) {
+		return func.copySet(obj);
+	},
+	[wrapKey(TYPE.OBJECT)](obj) {
+		return func.copyObj(obj);
+	},
+	[wrapKey(TYPE.ARRAY)](arr) {
+		return func.copyArray(arr);
+	},
+	[wrapKey(TYPE.NULL)]() {
+		return null;
+	},
+	[wrapKey(TYPE.UNDEFINED)]() {
+		return undefined;
+	},
+	[TYPE.PRIMITIVE](obj) {
+		return func.copyPrimitive(obj);
+	},
+};

--- a/src/utils/copyType.js
+++ b/src/utils/copyType.js
@@ -14,6 +14,9 @@ export const copy = {
 	[wrapKey(TYPE.ARRAY)](arr) {
 		return func.copyArray(arr);
 	},
+	[wrapKey(TYPE.SYMBOL)](val) {
+		return func.copySymbol(val);
+	},
 	[wrapKey(TYPE.NULL)]() {
 		return null;
 	},

--- a/src/utils/recurse.js
+++ b/src/utils/recurse.js
@@ -1,0 +1,15 @@
+import { deepCopy } from '..';
+import { ITERATE_TYPE } from './constants';
+
+export const recurse = {
+	[ITERATE_TYPE.FOR_IN](obj, setValueFunc) {
+		for (let key in obj) {
+			setValueFunc(key, deepCopy(obj[key]));
+		}
+	},
+	[ITERATE_TYPE.FOR_OF](obj, setValueFunc) {
+		for (let [key, value] of obj) {
+			setValueFunc(key, deepCopy(value));
+		}
+	},
+};


### PR DESCRIPTION
### description
- 리팩토링: if-else문, for문 대신 객체 메서드 축약표현을 사용해 공통로직 분리

<br>

### question
1. 심볼타입 값의 경우는 어떻게 깊은 복사를 구현해야할까요?
symbol type의 값을 깊은 복사하려다 보니 이런 어려움이 있었습니다:
- 복사하려는 심볼값은 다른 원시타입의 값처럼 다른 변수에 값을 할당해도 복사되지 않음
- 새로운 심볼을 만들어 등록해도 전역 레지스트리에서 기존 값을 찾아 반환하기 때문에 다른 값을 동일하게 생성할 수 없음


<br>

3. 각 데이터 타입 식별하는 로직
- 참조형에 속하는 각 데이터 타입을 구분하기 위해 Object.prototype.toString.call() 메서드를 사용했습니다.
- [object Map] 형식으로 반환되는 값을 처리하기 위해 
인수로 전달받은 타입을 감싸 아래처럼 같은 형식의 문자열로 만들어주었습니다.
- 이게 좋은 방식일지, 더 좋은 방식이 있을지 궁금합니다.

```js
export const wrapKey = (type) => {
	return `[object ${type}]`;
};
```